### PR TITLE
fix : show only this week in meal list

### DIFF
--- a/src/api/meal.ts
+++ b/src/api/meal.ts
@@ -8,25 +8,13 @@ import { api } from './api';
 
 // const today = +new Date()
 
-export const getWeeklyMeals = async (date: Date): Promise<DailyMeal[]> => {
-  const raw = (await api<'weeklyMeals'>('GET', '/meal/weekly')).meals;
-  return raw.reduce<DailyMeal[]>(
-    (matched, current) => {
-      const index = new Date(current.date).getDay() - 1;
-      return [...matched.slice(0, index), current, ...matched.slice(index + 1)];
-    },
-    [...Array(7)],
+export const getWeeklyMeals = async (date: Date): Promise<DailyMeal[]> =>
+  (await api<'weeklyMeals'>('GET', '/meal/weekly')).meals;
+
+export const getDailyMeal = (date: Date = new Date()) =>
+  api<'dailyMeal'>('GET', `/meal/date/${formatRequestableDate(date)}`).then(
+    (e) => e.meal,
   );
-
-  // return []
-};
-
-export const getDailyMeal = (date: Date = new Date()) => {
-  return api<'dailyMeal'>(
-    'GET',
-    `/meal/date/${formatRequestableDate(date)}`,
-  ).then((e) => e.meal);
-};
 
 export const requestMentoringApplyInfoSheet = () =>
   api<'requestMentoringApplyInfoSheet'>(


### PR DESCRIPTION
백엔드에서 주간 급식을 불러올 때 moment의 startOf, endOf를 사용해서 가져오기 때문에 fetch된 결과를 수정할 필요가 없습니다.

참고:
https://github.com/dimigoin/dimigoin-back-v3/blob/e01906a92a9d67d875a8268b154221e1f7d75ac4/src/services/meal/controllers.ts#L8-L17
https://github.com/dimigoin/dimigoin-back-v3/blob/e01906a92a9d67d875a8268b154221e1f7d75ac4/src/resources/date.ts#L26-L34