### PR TITLE
feat : rename movingClass group name to "아날로그"

### DIFF
--- a/src/pages/SelfStudyDisplay/index.tsx
+++ b/src/pages/SelfStudyDisplay/index.tsx
@@ -132,7 +132,7 @@ interface DisplayPlaceWithStudents extends DisplayPlace {
 const movingClass = {
   icon: <DeskIcon css={iconStyle} />,
   type: 'MOVING_CLASS',
-  name: '이동반',
+  name: '아날로그',
   isAvailable: true,
 };
 


### PR DESCRIPTION
이동반 운영 정책 변경에 의해 자습디스플레이에서 "이동반" 레이블을 "아날로그"로 변경합니다.